### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/asdf.yml
+++ b/.github/workflows/asdf.yml
@@ -18,7 +18,7 @@ jobs:
           WITH_V: true
           DEFAULT_BUMP: patch
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BOT_VERSION: ${{ steps.version_tag.outputs.new_tag }}
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore